### PR TITLE
Improve font-color in dark-theme

### DIFF
--- a/css/bootstrap/bootstrap-custom.css
+++ b/css/bootstrap/bootstrap-custom.css
@@ -1441,11 +1441,11 @@ table.ipaddresses td.gateway {
 }
 table.ipaddresses td.gateway ul li {
 	font-weight: normal;
-	color: #555;
+	color: #999;
 }
 table.ipaddresses td.gateway a i.fa-gateway {
 	margin-left: 5px;
-	color: #555;
+	color: #999;
 }
 table.ipaddress_subnet .alert {
     margin-bottom: 0px;


### PR DESCRIPTION
Improve font-color for ipaddress records for "gateway" when using dark-theme